### PR TITLE
fix: restore non-stream proxy compatibility

### DIFF
--- a/Sources/Copool/Infrastructure/SwiftNativeProxyRuntimeService+RequestTranslation.swift
+++ b/Sources/Copool/Infrastructure/SwiftNativeProxyRuntimeService+RequestTranslation.swift
@@ -5,7 +5,9 @@ extension SwiftNativeProxyRuntimeService {
         "prompt_cache_key",
         "prompt_cache_retention",
         "safety_identifier",
-        "service_tier"
+        "service_tier",
+        "max_output_tokens",
+        "temperature"
     ]
 
     func normalizeResponsesRequest(_ request: [String: Any]) throws -> (payload: [String: Any], downstreamStream: Bool) {

--- a/Sources/Copool/Infrastructure/SwiftNativeProxyRuntimeService+RequestTranslation.swift
+++ b/Sources/Copool/Infrastructure/SwiftNativeProxyRuntimeService+RequestTranslation.swift
@@ -312,6 +312,8 @@ extension SwiftNativeProxyRuntimeService {
         switch formatType {
         case "text":
             format["type"] = "text"
+        case "json_object":
+            format["type"] = "json_object"
         case "json_schema":
             format["type"] = "json_schema"
             if let schemaObject = formatObject["json_schema"] as? [String: Any] {

--- a/Sources/Copool/Infrastructure/SwiftNativeProxyRuntimeService+ResponseTranslation.swift
+++ b/Sources/Copool/Infrastructure/SwiftNativeProxyRuntimeService+ResponseTranslation.swift
@@ -396,6 +396,7 @@ extension SwiftNativeProxyRuntimeService {
     func extractCompletedResponse(fromSSE data: Data) throws -> [String: Any] {
         let events = parseSSEEvents(from: data)
         var lastJSON: [String: Any]?
+        var accumulator = CompletedResponseAccumulator()
 
         for event in events {
             guard event.data != "[DONE]" else { continue }
@@ -405,10 +406,11 @@ extension SwiftNativeProxyRuntimeService {
             }
 
             lastJSON = object
+            accumulator.observe(object)
 
             if (object["type"] as? String) == "response.completed",
                let response = object["response"] as? [String: Any] {
-                return response
+                return accumulator.finalize(response)
             }
 
             if object["id"] != nil, object["output"] != nil {
@@ -466,6 +468,31 @@ struct ChatStreamState {
     var functionCallIndex: Int
     var hasReceivedArgumentsDelta: Bool
     var hasToolCallAnnounced: Bool
+}
+
+private struct CompletedResponseAccumulator {
+    private var outputItems: [Int: [String: Any]] = [:]
+
+    mutating func observe(_ object: [String: Any]) {
+        guard (object["type"] as? String) == "response.output_item.done",
+              let item = object["item"] as? [String: Any] else {
+            return
+        }
+
+        let index = object["output_index"] as? Int ?? outputItems.count
+        outputItems[index] = item
+    }
+
+    func finalize(_ response: [String: Any]) -> [String: Any] {
+        let currentOutput = response["output"] as? [Any] ?? []
+        guard currentOutput.isEmpty, !outputItems.isEmpty else {
+            return response
+        }
+
+        var updated = response
+        updated["output"] = outputItems.keys.sorted().compactMap { outputItems[$0] }
+        return updated
+    }
 }
 
 final class ChatCompletionsSSEStreamDecoder: @unchecked Sendable {

--- a/Sources/Copool/Resources/proxyd-src/src/proxy_service.rs
+++ b/Sources/Copool/Resources/proxyd-src/src/proxy_service.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::fs;
 use std::io::Write;
@@ -67,6 +68,8 @@ const UNSUPPORTED_RESPONSES_FORWARDING_KEYS: &[&str] = &[
     "prompt_cache_retention",
     "safety_identifier",
     "service_tier",
+    "max_output_tokens",
+    "temperature",
 ];
 const SSE_DONE: &str = "data: [DONE]\n\n";
 const MODELS: &[&str] = &[
@@ -177,6 +180,44 @@ struct SseDecoder {
 struct SseEvent {
     event: Option<String>,
     data: String,
+}
+
+#[derive(Default)]
+struct CompletedResponseAccumulator {
+    output_items: BTreeMap<u64, Value>,
+}
+
+impl CompletedResponseAccumulator {
+    fn observe(&mut self, event: &SseEvent) {
+        let Ok(parsed) = serde_json::from_str::<Value>(&event.data) else {
+            return;
+        };
+        if parsed.get("type").and_then(Value::as_str) != Some("response.output_item.done") {
+            return;
+        }
+
+        let Some(item) = parsed.get("item").cloned() else {
+            return;
+        };
+        let index = parsed
+            .get("output_index")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.output_items.len() as u64);
+        self.output_items.insert(index, item);
+    }
+
+    fn finalize_response(&self, response: Value) -> Value {
+        if !response_output_is_empty(&response) || self.output_items.is_empty() {
+            return response;
+        }
+
+        let mut response_object = response.as_object().cloned().unwrap_or_default();
+        response_object.insert(
+            "output".to_string(),
+            Value::Array(self.output_items.values().cloned().collect()),
+        );
+        Value::Object(response_object)
+    }
 }
 
 struct ChatStreamState {
@@ -2360,23 +2401,30 @@ fn extract_completed_response_from_sse(bytes: &[u8]) -> Result<Value, String> {
             return value
                 .get("response")
                 .cloned()
+                .map(|response| CompletedResponseAccumulator::default().finalize_response(response))
                 .ok_or_else(|| "Codex 响应缺少 response 字段".to_string());
         }
     }
 
     let mut decoder = SseDecoder::default();
+    let mut accumulator = CompletedResponseAccumulator::default();
+    let mut completed_response = None;
     for event in decoder.push(bytes) {
+        accumulator.observe(&event);
         if let Some(response) = response_completed_from_event(&event) {
-            return Ok(response);
+            completed_response = Some(response);
         }
     }
     for event in decoder.finish() {
+        accumulator.observe(&event);
         if let Some(response) = response_completed_from_event(&event) {
-            return Ok(response);
+            completed_response = Some(response);
         }
     }
 
-    Err("未在 Codex SSE 中找到 response.completed 事件".to_string())
+    completed_response
+        .map(|response| accumulator.finalize_response(response))
+        .ok_or_else(|| "未在 Codex SSE 中找到 response.completed 事件".to_string())
 }
 
 fn response_completed_from_event(event: &SseEvent) -> Option<Value> {
@@ -2385,6 +2433,14 @@ fn response_completed_from_event(event: &SseEvent) -> Option<Value> {
         return None;
     }
     parsed.get("response").cloned()
+}
+
+fn response_output_is_empty(response: &Value) -> bool {
+    response
+        .get("output")
+        .and_then(Value::as_array)
+        .map(|output| output.is_empty())
+        .unwrap_or(true)
 }
 
 fn convert_completed_response_to_chat_completion(response: &Value) -> Value {
@@ -2964,6 +3020,7 @@ mod tests {
     use super::current_selection_matches;
     use super::extract_completed_response_from_sse;
     use super::map_client_model_to_upstream;
+    use super::MODELS;
     use super::normalize_openai_responses_request;
     use super::normalize_model_for_client;
     use super::ProxyCandidate;
@@ -3113,6 +3170,22 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("input_text")
         );
+    }
+
+    #[test]
+    fn strips_responses_parameters_rejected_by_codex_upstream() {
+        let request = json!({
+            "model": "gpt-5.4",
+            "input": "hello",
+            "max_output_tokens": 32,
+            "temperature": 0.1
+        });
+
+        let (payload, _) =
+            normalize_openai_responses_request(request).expect("request should normalize");
+
+        assert!(payload.get("max_output_tokens").is_none());
+        assert!(payload.get("temperature").is_none());
     }
 
     #[test]
@@ -3320,6 +3393,30 @@ data: {"type":"response.completed","response":{"id":"resp_123","created_at":1,"m
                 .and_then(|value| value.get("type"))
                 .and_then(|value| value.as_str()),
             Some("message")
+        );
+    }
+
+    #[test]
+    fn extracts_completed_response_from_sse_body_when_output_only_exists_in_output_item_done() {
+        let body = br#"event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"msg_123","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"OK"}]},"output_index":1,"sequence_number":9}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_123","created_at":1,"model":"gpt-5","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}
+
+"#;
+
+        let response =
+            extract_completed_response_from_sse(body).expect("response.completed expected");
+        assert_eq!(
+            response
+                .get("output")
+                .and_then(|value| value.get(0))
+                .and_then(|value| value.get("content"))
+                .and_then(|value| value.get(0))
+                .and_then(|value| value.get("text"))
+                .and_then(|value| value.as_str()),
+            Some("OK")
         );
     }
 

--- a/Sources/Copool/Resources/proxyd-src/src/proxy_service.rs
+++ b/Sources/Copool/Resources/proxyd-src/src/proxy_service.rs
@@ -1357,6 +1357,9 @@ fn map_response_format(root: &mut Map<String, Value>, response_format: &Value) {
         "text" => {
             format_object.insert("type".to_string(), Value::String("text".to_string()));
         }
+        "json_object" => {
+            format_object.insert("type".to_string(), Value::String("json_object".to_string()));
+        }
         "json_schema" => {
             format_object.insert("type".to_string(), Value::String("json_schema".to_string()));
             if let Some(schema_object) = response_format_object
@@ -3096,6 +3099,31 @@ mod tests {
         assert_eq!(
             payload.get("model").and_then(|value| value.as_str()),
             Some("gpt-5.4")
+        );
+    }
+
+    #[test]
+    fn maps_chat_json_object_response_format_to_upstream_text_format() {
+        let request = json!({
+            "model": "gpt-5.4",
+            "messages": [
+                { "role": "user", "content": "return valid json" }
+            ],
+            "response_format": {
+                "type": "json_object"
+            }
+        });
+
+        let (payload, _) =
+            convert_openai_chat_request_to_codex(&request).expect("payload should convert");
+
+        assert_eq!(
+            payload
+                .get("text")
+                .and_then(|value| value.get("format"))
+                .and_then(|value| value.get("type"))
+                .and_then(|value| value.as_str()),
+            Some("json_object")
         );
     }
 

--- a/Tests/CopoolTests/SwiftNativeProxyRuntimeServiceTests.swift
+++ b/Tests/CopoolTests/SwiftNativeProxyRuntimeServiceTests.swift
@@ -618,6 +618,36 @@ final class SwiftNativeProxyRuntimeServiceTests: XCTestCase {
         XCTAssertEqual(retainedUnsupportedKeys, [])
     }
 
+    func testResponsesNormalizationDropsMaxOutputTokensAndTemperature() async throws {
+        let runtime = SwiftNativeProxyRuntimeService(
+            paths: FileSystemPaths(
+                applicationSupportDirectory: URL(fileURLWithPath: "/tmp"),
+                accountStorePath: URL(fileURLWithPath: "/tmp/accounts.json"),
+                settingsStorePath: URL(fileURLWithPath: "/tmp/settings.json"),
+                codexAuthPath: URL(fileURLWithPath: "/tmp/auth.json"),
+                codexConfigPath: URL(fileURLWithPath: "/tmp/config.toml"),
+                proxyDaemonDataDirectory: URL(fileURLWithPath: "/tmp/proxyd", isDirectory: true),
+                proxyDaemonKeyPath: URL(fileURLWithPath: "/tmp/proxyd/api-proxy.key"),
+                cloudflaredLogDirectory: URL(fileURLWithPath: "/tmp/cloudflared-logs", isDirectory: true)
+            ),
+            storeRepository: MockStoreRepository(),
+            settingsRepository: MockSettingsRepository(),
+            authRepository: MockAuthRepository()
+        )
+
+        let retainedKeys = try await runtime.withIsolation { runtime in
+            let normalized = try runtime.normalizeResponsesRequest([
+                "model": "gpt-5.4",
+                "input": "hello",
+                "max_output_tokens": 32,
+                "temperature": 0.1
+            ])
+            return ["max_output_tokens", "temperature"].filter { normalized.payload[$0] != nil }
+        }
+
+        XCTAssertEqual(retainedKeys, [])
+    }
+
     func testResponsesNormalizationInjectsReasoningEffortFromModelAlias() async throws {
         let runtime = SwiftNativeProxyRuntimeService(
             paths: FileSystemPaths(
@@ -765,6 +795,27 @@ final class SwiftNativeProxyRuntimeServiceTests: XCTestCase {
         XCTAssertEqual(secondSnapshot.chunkCount, 2)
         XCTAssertEqual(secondSnapshot.firstContent, "Hello")
         XCTAssertEqual(secondSnapshot.finishReason, "stop")
+    }
+
+    func testExtractCompletedResponseBackfillsOutputFromOutputItemDoneEvent() async throws {
+        let runtime = makeRuntime(store: AccountsStore())
+
+        let response = try await runtime.withIsolation { runtime in
+            try runtime.extractCompletedResponse(
+                fromSSE: Data("""
+                event: response.output_item.done
+                data: {"type":"response.output_item.done","item":{"id":"msg_123","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"OK"}]},"output_index":1,"sequence_number":9}
+
+                event: response.completed
+                data: {"type":"response.completed","response":{"id":"resp_123","created_at":1,"model":"gpt-5","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}
+
+                """.utf8)
+            )
+        }
+
+        let output = response["output"] as? [[String: Any]]
+        let content = output?.first?["content"] as? [[String: Any]]
+        XCTAssertEqual(content?.first?["text"] as? String, "OK")
     }
 
     func testPayloadOversizeDetectionFromContentLengthHeader() {

--- a/Tests/CopoolTests/SwiftNativeProxyRuntimeServiceTests.swift
+++ b/Tests/CopoolTests/SwiftNativeProxyRuntimeServiceTests.swift
@@ -749,6 +749,42 @@ final class SwiftNativeProxyRuntimeServiceTests: XCTestCase {
         XCTAssertEqual(normalizedReasoningEffort, "high")
     }
 
+    func testChatConversionMapsJSONResponseFormatToTextFormatType() async throws {
+        let runtime = SwiftNativeProxyRuntimeService(
+            paths: FileSystemPaths(
+                applicationSupportDirectory: URL(fileURLWithPath: "/tmp"),
+                accountStorePath: URL(fileURLWithPath: "/tmp/accounts.json"),
+                settingsStorePath: URL(fileURLWithPath: "/tmp/settings.json"),
+                codexAuthPath: URL(fileURLWithPath: "/tmp/auth.json"),
+                codexConfigPath: URL(fileURLWithPath: "/tmp/config.toml"),
+                proxyDaemonDataDirectory: URL(fileURLWithPath: "/tmp/proxyd", isDirectory: true),
+                proxyDaemonKeyPath: URL(fileURLWithPath: "/tmp/proxyd/api-proxy.key"),
+                cloudflaredLogDirectory: URL(fileURLWithPath: "/tmp/cloudflared-logs", isDirectory: true)
+            ),
+            storeRepository: MockStoreRepository(),
+            settingsRepository: MockSettingsRepository(),
+            authRepository: MockAuthRepository()
+        )
+
+        let mappedType = try await runtime.withIsolation { runtime in
+            let normalized = try runtime.convertChatRequestToResponses([
+                "model": "GPT-5.4",
+                "messages": [
+                    [
+                        "role": "user",
+                        "content": "return valid json"
+                    ]
+                ],
+                "response_format": [
+                    "type": "json_object"
+                ]
+            ])
+            return ((normalized.payload["text"] as? [String: Any])?["format"] as? [String: Any])?["type"] as? String
+        }
+
+        XCTAssertEqual(mappedType, "json_object")
+    }
+
     func testStreamingChatTranslatorEmitsChunksIncrementally() async throws {
         let runtime = makeRuntime(store: AccountsStore())
         let decoder = await runtime.withIsolation { runtime in


### PR DESCRIPTION
## Summary
- restore non-stream proxy responses by backfilling completed outputs from prior SSE output-item events
- support `response_format={"type":"json_object"}` when mapping chat completions to upstream text format
- drop `max_output_tokens` and `temperature` from Responses forwarding where the Codex upstream rejects them

## Verification
- `cargo test --manifest-path Sources/Copool/Resources/proxyd-src/proxyd/Cargo.toml extracts_completed_response_from_sse_body_when_output_only_exists_in_output_item_done`
- `cargo test --manifest-path Sources/Copool/Resources/proxyd-src/proxyd/Cargo.toml strips_responses_parameters_rejected_by_codex_upstream`
- `cargo test --manifest-path Sources/Copool/Resources/proxyd-src/proxyd/Cargo.toml maps_chat_json_object_response_format_to_upstream_text_format`
- rebuilt local `Copool.app`, deployed it to `~/Applications/Copool.app`, and verified from the Dockerized `ai-goofish-monitor` app that non-stream `chat.completions`, `responses`, and `chat.completions + response_format=json_object` all return content successfully